### PR TITLE
Fix os family init scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Below an overview of all changes in the releases.
 
+0.0.4 
+
+ * Bug with init script, osfamily
+
 Version (Release date)
 
 0.0.3   (2014-08-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Below an overview of all changes in the releases.
 
+# lots of stuff
+
 0.0.4 
 
  * Bug with init script, osfamily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,20 @@
 Below an overview of all changes in the releases.
 
 0.0.4 
+
  * Bug with init script, osfamily
 
 Version (Release date)
 
 0.0.3   (2014-08-28)
+
   * Small bug fix. Not recognize repo_name. If statement went alway into "else".
 
 0.0.2   (2014-08-20)
+
   * Package ruby-devel not available on Ubuntu. Fixed.
   * Added correct init script for debian/ubuntu systems.
 
 0.0.1  (2014-08-01)
+
   * Initial working version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,16 @@
 Below an overview of all changes in the releases.
 
 0.0.4 
-
  * Bug with init script, osfamily
 
 Version (Release date)
 
 0.0.3   (2014-08-28)
-
   * Small bug fix. Not recognize repo_name. If statement went alway into "else".
 
 0.0.2   (2014-08-20)
-
   * Package ruby-devel not available on Ubuntu. Fixed.
   * Added correct init script for debian/ubuntu systems.
 
 0.0.1  (2014-08-01)
- 
   * Initial working version.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,8 @@ class webhook (
   $ruby_dev        = $webhook::params::ruby_dev,
 ) inherits webhook::params {
 
+  osfamily = inline_template('<%= osfamily.downcase %>')
+
   exec { 'create_webhook_homedir':
     command => "mkdir -p ${webhook_home}",
     path    => '/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class webhook (
   file { '/etc/init.d/webhook':
     ensure  => present,
     mode    => '0775',
-    content => template("webhook/service.${::osfamily}.erb"),
+    content => template("webhook/service.${osfamily}.erb"),
   }
 
   if ! defined(Package[$ruby_dev]) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@ class webhook (
   $ruby_dev        = $webhook::params::ruby_dev,
 ) inherits webhook::params {
 
-  osfamily = inline_template('<%= osfamily.downcase %>')
+  $osfamily = inline_template('<%= osfamily.downcase %>')
 
   exec { 'create_webhook_homedir':
     command => "mkdir -p ${webhook_home}",

--- a/templates/service.redhat.erb
+++ b/templates/service.redhat.erb
@@ -25,7 +25,7 @@ PATH="${PATH}:${GEM_PATH}/bin"
 start() { 
     # Start our daemon
     echo -n "Starting webhook: "
-    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d
+    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d -q
     RETVAL=$?
 
     #If all is well touch the lock file

--- a/templates/service.redhat.erb
+++ b/templates/service.redhat.erb
@@ -25,7 +25,7 @@ PATH="${PATH}:${GEM_PATH}/bin"
 start() { 
     # Start our daemon
     echo -n "Starting webhook: "
-    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d 
+    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d -q 
     RETVAL=$?
 
     #If all is well touch the lock file

--- a/templates/service.redhat.erb
+++ b/templates/service.redhat.erb
@@ -25,7 +25,7 @@ PATH="${PATH}:${GEM_PATH}/bin"
 start() { 
     # Start our daemon
     echo -n "Starting webhook: "
-    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d -q
+    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d 
     RETVAL=$?
 
     #If all is well touch the lock file

--- a/templates/service.redhat.erb
+++ b/templates/service.redhat.erb
@@ -25,7 +25,7 @@ PATH="${PATH}:${GEM_PATH}/bin"
 start() { 
     # Start our daemon
     echo -n "Starting webhook: "
-    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d -
+    thin start --environment production --port ${WEBHOOK_PORT} -P ${WEBHOOK_PID}  -l ${WEBHOOK_LOG} -c ${WEBHOOK_HOME} -d
     RETVAL=$?
 
     #If all is well touch the lock file


### PR DESCRIPTION
There were some bugs in the implementation.

1) The template files were lowercase, but Os Family is in uppercases. Added code to downcase osfamily.
2) Also made osfamily as a local variable and reference that as a local variable in the template function.
3) Finally, startup in init script was missing a "q", which caused then not to start up on Red Hat family. Added that in.