### PR TITLE
Added MCO Support, fixed a number of bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #wdijkerman-webhook release
-
+# Change log file
 Below an overview of all changes in the releases.
 
 # lots of stuff

--- a/files/webhook_config.json
+++ b/files/webhook_config.json
@@ -1,6 +1,6 @@
 { 
   "r10k_cmd": "/usr/bin/r10k",
-  "mco": true,
+  "mco": false,
   "mco_cmd": "/usr/bin/mco r10k",
   "mco_user": "mcollective-user"
 }

--- a/files/webhook_config.json
+++ b/files/webhook_config.json
@@ -1,0 +1,3 @@
+{ 
+  "r10k_cmd": "/usr/bin/r10k environment -pv"
+}

--- a/files/webhook_config.json
+++ b/files/webhook_config.json
@@ -1,3 +1,6 @@
 { 
-  "r10k_cmd": "/usr/bin/r10k environment -pv"
+  "r10k_cmd": "/usr/bin/r10k environment",
+  "mco": true,
+  "mco_cmd": "/usr/bin/mco r10k",
+  "mco_user": "mcollective-user"
 }

--- a/files/webhook_config.json
+++ b/files/webhook_config.json
@@ -1,5 +1,5 @@
 { 
-  "r10k_cmd": "/usr/bin/r10k environment",
+  "r10k_cmd": "/usr/bin/r10k",
   "mco": true,
   "mco_cmd": "/usr/bin/mco r10k",
   "mco_user": "mcollective-user"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@
 # [*ruby_dev*]
 # The package name of ruby-devel (or when debian: ruby-dev)
 #
+# [*mco*]
+# Enables mco. Defaults to false (lowercase). See params.pp for explanation.
+# [*mco_user*]
+# The user being utilized to invoke mco r10k. Defaults to mcollective-user
 # === Example
 #
 #  class { 'webhook':
@@ -56,6 +60,8 @@ class webhook (
   $webhook_port    = $webhook::params::port,
   $webhook_owner   = $webhook::params::owner,
   $webhook_group   = $webhook::params::group,
+  $mco             = $webhook::params::mco,
+  $mco_user        = $webhook::params::mco_user,
   $repo_puppetfile = undef,
   $repo_hieradata  = undef,
   $ruby_dev        = $webhook::params::ruby_dev,
@@ -83,7 +89,7 @@ class webhook (
     owner   => $webhook_owner,
     group   => $webhook_group,
     mode    => '0644',
-    source  => 'puppet:///modules/webhook/webhook_config.json',
+    content => template('webhook/webhook/webhook_config.json.erb'),
     require => Exec['create_webhook_homedir'],
     notify  => Service['webhook'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,16 @@ class webhook (
     require => Exec['create_webhook_homedir'],
   }
 
+  file { "${webhook_home}/webhook_config.json":
+    ensure  => present,
+    owner   => $webhook_owner,
+    group   => $webhook_group,
+    mode    => '0644',
+    source  => 'puppet:///modules/webhook/webhook_config.json',
+    require => Exec['create_webhook_homedir'],
+    notify  => Service['webhook'],
+  }
+
   file { "${webhook_home}/Gemfile":
     ensure  => present,
     owner   => $webhook_owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@
 # Enables mco. Defaults to false (lowercase). See params.pp for explanation.
 # [*mco_user*]
 # The user being utilized to invoke mco r10k. Defaults to mcollective-user
+#
 # === Example
 #
 #  class { 'webhook':
@@ -89,7 +90,7 @@ class webhook (
     owner   => $webhook_owner,
     group   => $webhook_group,
     mode    => '0644',
-    content => template('webhook/webhook/webhook_config.json.erb'),
+    content => template('webhook/webhook_config.json.erb'),
     require => Exec['create_webhook_homedir'],
     notify  => Service['webhook'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,8 @@ class webhook::params {
   $port     = '81'
   $owner    = 'root'
   $group    = 'root'
+  $mco      = 'false' # Important, since we are writing to a json file and Json only do lowercase boolean.
+  $mco_user = 'mcollective-user' # the user being utilized to invoke mco r10k
 
   # OS specific stuff
   if $::osfamily == 'RedHat' {

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -27,9 +27,10 @@ post '/payload' do
     logger.info("Deploy r10k for this environment #{branchName}")
     deployEnv(branchName,webhook_config_obj)
   else
-    logger.info("Deploy puppet module #{repo_name}")
+    module_name = repo_name.split('-').pop
+    logger.info("Deploy puppet module #{module_name}")
     logger.info("Running for branch #{branchName}")
-    deployModule(repo_name,webhook_config_obj)
+    deployModule(module_name,webhook_config_obj)
   end
 end
 

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -35,11 +35,11 @@ end
 
 # Some defines.
 def deployEnv(branchname,cmd_obj)
-  deployCmd = "#{cmd['r10k_cmd']} #{branchname} -pv"
+  deployCmd = "#{cmd_obj['r10k_cmd']} #{branchname} -pv"
   `#{deployCmd}`
 end
 
 def deployModule(modulename,cmd_obj)
-  deployCmd = "#{cmd['r10k_cmd']} module #{modulename} -pv"
+  deployCmd = "#{cmd_obj['r10k_cmd']} module #{modulename} -pv"
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -35,13 +35,27 @@ end
 
 # Some defines.
 def deployEnv(branchname,cmd_obj)
-  deployCmd = "#{cmd_obj['r10k_cmd']} deploy environment #{branchname} -pv"
+  if cmd_obj['mco'] # Check to see if we are using mco
+    if cmd_obj['mco_user'] # run it as a mco user if specified
+      deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{branchname}'"
+    else # if we are running mco as root
+      deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy #{branchname}"
+  else # use deefaults
+    deployCmd = "#{cmd_obj['r10k_cmd']} deploy environment #{branchname} -pv"
+  end
   logger.info("Now running #{deployCmd}")
   `#{deployCmd}`
 end
 
 def deployModule(modulename,cmd_obj)
-  deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
+  if cmd_obj['mco'] # Check to see if we are using mco
+    if cmd_obj['mco_user'] # run it as a mco user if specified
+      deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{modulename}'"
+    else
+      deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy_module #{modulename}"
+  else # use defaults
+    deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
+  end
   logger.info("Now running #{deployCmd}")
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -37,7 +37,7 @@ end
 def deployEnv(branchname,cmd_obj)
   if cmd_obj['mco'] # Check to see if we are using mco
     if cmd_obj['mco_user'] # run it as a mco user if specified
-      deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{branchname}'"
+      deployCmd = "/bin/su #{cmd_obj['mco_user']} -c '#{cmd_obj['mco_cmd']} deploy #{branchname}'"
     else # if we are running mco as root
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy #{branchname}"
     end
@@ -51,7 +51,7 @@ end
 def deployModule(modulename,cmd_obj)
   if cmd_obj['mco'] # Check to see if we are using mco
     if cmd_obj['mco_user'] # run it as a mco user if specified
-      deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{modulename}'"
+      deployCmd = "/bin/su #{cmd_obj['mco_user']} -c '#{cmd_obj['mco_cmd']} deploy #{modulename}'"
     else
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy_module #{modulename}"
     end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -35,11 +35,11 @@ end
 
 # Some defines.
 def deployEnv(branchname,cmd_obj)
-  deployCmd = "#{cmd_obj['r10k_cmd']} #{branchname} -pv"
+  deployCmd = "#{cmd_obj['r10k_cmd']} deploy #{branchname} -pv"
   `#{deployCmd}`
 end
 
 def deployModule(modulename,cmd_obj)
-  deployCmd = "#{cmd_obj['r10k_cmd']} module #{modulename} -pv"
+  deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -36,10 +36,12 @@ end
 # Some defines.
 def deployEnv(branchname,cmd_obj)
   deployCmd = "#{cmd_obj['r10k_cmd']} deploy #{branchname} -pv"
+  logger.info("Now running #{deployCMD}")
   `#{deployCmd}`
 end
 
 def deployModule(modulename,cmd_obj)
   deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
+  logger.info("Now running #{deployCMD}")
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -23,7 +23,7 @@ post '/payload' do
   logger.info("branch = #{branchName}")
 
   # Check if repo_name is 'puppetfile'
-  if #{repo_name} == #{repo_puppetfile} <% if @repo_hieradata %>|| #{repo_name} == #{repo_hieradata}<% end %>
+  if repo_name == repo_puppetfile <% if @repo_hieradata %>|| #{repo_name} == #{repo_hieradata}<% end %>
     logger.info("Deploy r10k for this environment #{branchName}")
     deployEnv(branchName,webhook_config_obj)
   else

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -35,7 +35,7 @@ end
 
 # Some defines.
 def deployEnv(branchname,cmd_obj)
-  deployCmd = "#{cmd_obj['r10k_cmd']} deploy #{branchname} -pv"
+  deployCmd = "#{cmd_obj['r10k_cmd']} deploy environment #{branchname} -pv"
   logger.info("Now running #{deployCmd}")
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -57,7 +57,7 @@ def deployModule(modulename,cmd_obj)
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy_module #{modulename}"
     end
   else # use defaults
-    deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
+    deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -v"
   end
   logger.info("Now running #{deployCmd}")
   `#{deployCmd}`

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -23,7 +23,7 @@ post '/payload' do
   logger.info("branch = #{branchName}")
 
   # Check if repo_name is 'puppetfile'
-  if repo_name == repo_puppetfile <% if @repo_hieradata %>|| #{repo_name} == #{repo_hieradata}<% end %>
+  if repo_name == repo_puppetfile <% if @repo_hieradata %>|| repo_name == repo_hieradata <% end %>
     logger.info("Deploy r10k for this environment #{branchName}")
     deployEnv(branchName,webhook_config_obj)
   else
@@ -51,7 +51,7 @@ end
 def deployModule(modulename,cmd_obj)
   if cmd_obj['mco'] # Check to see if we are using mco
     if cmd_obj['mco_user'] # run it as a mco user if specified
-      deployCmd = "/bin/su #{cmd_obj['mco_user']} -c '#{cmd_obj['mco_cmd']} deploy #{modulename}'"
+      deployCmd = "/bin/su #{cmd_obj['mco_user']} -c '#{cmd_obj['mco_cmd']} deploy_module #{modulename}'"
     else
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy_module #{modulename}"
     end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -7,6 +7,8 @@ repo_puppetfile = "<%= @repo_puppetfile %>"
 repo_hierdata   = "<%= @repo_hieradata %>"
 <% end -%>
 
+webhook_config_obj = JSON.parse(File.read((Dir.pwd) + "/webhook_config.json"))
+
 post '/payload' do
   push = JSON.parse(request.body.read)
   logger.info("json payload: #{push.inspect}")
@@ -23,21 +25,21 @@ post '/payload' do
   # Check if repo_name is 'puppetfile'
   if #{repo_name} == #{repo_puppetfile} <% if @repo_hieradata %>|| #{repo_name} == #{repo_hieradata}<% end %>
     logger.info("Deploy r10k for this environment #{branchName}")
-    deployEnv(branchName)
+    deployEnv(branchName,webhook_config_obj["r10k_cmd"])
   else
     logger.info("Deploy puppet module #{repo_name}")
     logger.info("Running for branch #{branchName}")
-    deployModule(repo_name)
+    deployModule(repo_name,webhook_config_obj["r10k_cmd"])
   end
 end
 
 # Some defines.
-def deployEnv(branchname)
-  deployCmd = "/usr/bin/r10k deploy environment #{branchname} -pv"
+def deployEnv(branchname,cmd)
+  deployCmd = "#{cmd} #{branchname}"
   `#{deployCmd}`
 end
 
 def deployModule(modulename)
-  deployCmd = "/usr/bin/r10k deploy module #{modulename} -v"
+  deployCmd = "#{cmd}_module #{modulename}"
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -36,12 +36,12 @@ end
 # Some defines.
 def deployEnv(branchname,cmd_obj)
   deployCmd = "#{cmd_obj['r10k_cmd']} deploy #{branchname} -pv"
-  logger.info("Now running #{deployCMD}")
+  logger.info("Now running #{deployCmd}")
   `#{deployCmd}`
 end
 
 def deployModule(modulename,cmd_obj)
   deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
-  logger.info("Now running #{deployCMD}")
+  logger.info("Now running #{deployCmd}")
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -25,21 +25,21 @@ post '/payload' do
   # Check if repo_name is 'puppetfile'
   if #{repo_name} == #{repo_puppetfile} <% if @repo_hieradata %>|| #{repo_name} == #{repo_hieradata}<% end %>
     logger.info("Deploy r10k for this environment #{branchName}")
-    deployEnv(branchName,webhook_config_obj["r10k_cmd"])
+    deployEnv(branchName,webhook_config_obj)
   else
     logger.info("Deploy puppet module #{repo_name}")
     logger.info("Running for branch #{branchName}")
-    deployModule(repo_name,webhook_config_obj["r10k_cmd"])
+    deployModule(repo_name,webhook_config_obj)
   end
 end
 
 # Some defines.
-def deployEnv(branchname,cmd)
-  deployCmd = "#{cmd} #{branchname}"
+def deployEnv(branchname,cmd_obj)
+  deployCmd = "#{cmd['r10k_cmd']} #{branchname} -pv"
   `#{deployCmd}`
 end
 
-def deployModule(modulename)
-  deployCmd = "#{cmd}_module #{modulename}"
+def deployModule(modulename,cmd_obj)
+  deployCmd = "#{cmd['r10k_cmd']} module #{modulename} -pv"
   `#{deployCmd}`
 end

--- a/templates/webhook.rb
+++ b/templates/webhook.rb
@@ -40,6 +40,7 @@ def deployEnv(branchname,cmd_obj)
       deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{branchname}'"
     else # if we are running mco as root
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy #{branchname}"
+    end
   else # use deefaults
     deployCmd = "#{cmd_obj['r10k_cmd']} deploy environment #{branchname} -pv"
   end
@@ -53,6 +54,7 @@ def deployModule(modulename,cmd_obj)
       deployCmd = "/bin/su #{cmd_obj['mco_user']} '#{cmd_obj['mco_cmd']} deploy #{modulename}'"
     else
       deployCmd = "#{cmd_obj['mco_user']} #{cmd_obj['mco_cmd']} deploy_module #{modulename}"
+    end
   else # use defaults
     deployCmd = "#{cmd_obj['r10k_cmd']} deploy module #{modulename} -pv"
   end

--- a/templates/webhook_config.json.erb
+++ b/templates/webhook_config.json.erb
@@ -1,0 +1,6 @@
+{ 
+  "r10k_cmd": "/usr/bin/r10k",
+  "mco": <%= @mco %>,
+  "mco_cmd": "/usr/bin/mco r10k",
+  "mco_user": "<%= @mco_user %>"
+}


### PR DESCRIPTION
Hi! I made some changes to the code:

Chiefly, I added support for running r10k via mcollective, which meant that it will work with deployments with multiple masters. It involves performing the following:

- Add config file for webhook to read off from. The file is managed by puppet as a template. This avoids managing the webhook directly and instead just manage the config, which reduce simultaneous maintenance of webhook ruby cookbook and puppet code.
- Added a boolean option to enable r10k via mcollective. By default, it is set to false (to main old behavior).
- In addition, you can run mco r10k via a specific user authorized to use mcollective (by default, mcollective-user).

Also:

- There was a bug with the comparison, which is now fixed.
- Also, fixed bug where repo-name does not match the module name.

In both cases, the above bugs prevented individual modules from being synced. The above fixes resolved the issue.